### PR TITLE
Add the Inverse Gaussian Distribution

### DIFF
--- a/docs/distributions.md
+++ b/docs/distributions.md
@@ -29,8 +29,7 @@ All distributions are based on `scipy.stats` distributions. We implement the pro
 | [`DistributionLogNormalMedian`](#ondil.DistributionLogNormalMedian)       | Log-normal distribution (median)       | -                       |
 | [`DistributionLogistic`](#ondil.DistributionLogistic)                     | Logistic distribution                  | `scipy.stats.logistic`  |
 | [`DistributionExponential`](#ondil.DistributionExponential)               | Exponential distribution               | `scipy.stats.expon`     |
-
-
+| [`DistributionInverseGaussian`](#ondil.DistributionInverseGaussian)       | Inverse Gaussian distribution          | `scipy.stats.invgauss`  |
 
 ## API Reference
 
@@ -51,6 +50,8 @@ All distributions are based on `scipy.stats` distributions. We implement the pro
 ::: ondil.DistributionLogistic
 
 ::: ondil.DistributionExponential
+
+::: ondil.DistributionInverseGaussian
 
 
 ## Base Class

--- a/src/ondil/__init__.py
+++ b/src/ondil/__init__.py
@@ -18,19 +18,17 @@ from .coordinate_descent import (
     soft_threshold,
 )
 from .distributions import (
+    DistributionBeta,
+    DistributionExponential,
     DistributionGamma,
+    DistributionInverseGaussian,
     DistributionJSU,
+    DistributionLogistic,
     DistributionLogNormal,
     DistributionLogNormalMedian,
     DistributionNormal,
     DistributionNormalMeanVariance,
     DistributionT,
-    DistributionLogNormalMedian,
-    DistributionLogNormal,
-    DistributionLogistic,
-    DistributionBeta,
-    DistributionExponential,
-
 )
 from .error import OutOfSupportError
 from .estimators import OnlineGamlss, OnlineLasso, OnlineLinearModel
@@ -50,13 +48,13 @@ from .link import (
     InverseSoftPlusShiftTwoLink,
     InverseSoftPlusShiftValueLink,
     LogIdentLink,
+    LogitLink,
     LogLink,
     LogShiftTwoLink,
     LogShiftValueLink,
     SqrtLink,
     SqrtShiftTwoLink,
     SqrtShiftValueLink,
-    LogitLink,
 )
 from .methods import (
     ElasticNetPathMethod,
@@ -104,6 +102,9 @@ __all__ = [
     "DistributionJSU",
     "DistributionGamma",
     "DistributionBeta",
+    "DistributionLogNormal",
+    "DistributionExponential",
+    "DistributionInverseGaussian",
     "init_forget_vector",
     "init_gram",
     "update_gram",

--- a/src/ondil/distributions/__init__.py
+++ b/src/ondil/distributions/__init__.py
@@ -1,12 +1,13 @@
-from .gamma import DistributionGamma
-from .johnsonsu import DistributionJSU
-from .normal import DistributionNormal, DistributionNormalMeanVariance
-from .studentt import DistributionT
 from .beta import DistributionBeta
+from .exponential import DistributionExponential
+from .gamma import DistributionGamma
+from .inversegaussian import DistributionInverseGaussian
+from .johnsonsu import DistributionJSU
+from .logistic import DistributionLogistic
 from .lognormal import DistributionLogNormal
 from .lognormalmedian import DistributionLogNormalMedian
-from .logistic import DistributionLogistic
-from .exponential import DistributionExponential
+from .normal import DistributionNormal, DistributionNormalMeanVariance
+from .studentt import DistributionT
 
 __all__ = [
     "DistributionNormal",
@@ -19,4 +20,5 @@ __all__ = [
     "DistributionLogNormalMedian",
     "DistributionLogistic",
     "DistributionExponential",
+    "DistributionInverseGaussian",
 ]

--- a/src/ondil/distributions/inversegaussian.py
+++ b/src/ondil/distributions/inversegaussian.py
@@ -1,0 +1,98 @@
+import numpy as np
+import scipy.stats as st
+
+from ..base import Distribution, LinkFunction, ScipyMixin
+from ..link import LogLink
+
+
+class DistributionInverseGaussian(ScipyMixin, Distribution):
+    """
+    Inverse Gaussian (Wald) distribution for GAMLSS.
+
+    This distribution is characterized by two parameters:
+    - $\\mu$: the mean of the distribution.
+    - $\\sigma$: the scale parameter, which is related to the variance.
+
+    The probability density function (PDF) is given by:
+    $$
+        f(y; \\mu, \\sigma) = \\sqrt{\\frac{\\sigma}{2\\pi y^3}} \\exp\\left(-\\frac{(y - \\mu)^2}{2\\sigma^2 y}\\right)
+    $$
+    where $y > 0$, $\\mu > 0$, and $\\sigma > 0$.
+
+    Note that the Inverse Gaussian distribution in `scipy.stats` is parameterized differently:
+
+    * `mu` is the mean of the distribution.
+    * `scale` is the scale parameter
+
+    and the PDF is given by:
+    $$
+        f(y; \\mu, \\lambda) = \\sqrt{\\frac{\\lambda}{2\\pi y^3}} \\exp\\left(-\\frac{\\lambda (y - \\mu)^2}{2\\mu^2 y}\\right)
+    $$
+    where $y > 0$, $\\mu > 0$, and $\\lambda > 0$.
+
+    The relationship between the parameters is:
+
+    * `mu` in `scipy.stats` corresponds to $\\mu \\sigma^2$ in this implementation,
+    * `scale` in `scipy.stats` corresponds to $1 / \\sigma^2$ in this implementation.
+    * The `loc` parameter in `scipy.stats` is always 0.
+
+    """
+
+    corresponding_gamlss: str = "IG"
+    parameter_names = {0: "mu", 1: "sigma"}
+    parameter_support = {
+        0: (np.nextafter(0, 1), np.inf),
+        1: (np.nextafter(0, 1), np.inf),
+    }
+    distribution_support = (np.nextafter(0, 1), np.inf)
+    scipy_dist = st.invgauss
+    scipy_names = {"mu": "mu", "sigma": "scale"}
+
+    def __init__(
+        self,
+        loc_link: LinkFunction = LogLink(),
+        scale_link: LinkFunction = LogLink(),
+    ) -> None:
+        super().__init__(
+            links={
+                0: loc_link,
+                1: scale_link,
+            }
+        )
+
+    def theta_to_scipy_params(self, theta: np.ndarray) -> dict:
+        mu, sigma = self.theta_to_params(theta)
+        return {"mu": mu * sigma**2, "loc": 0, "scale": 1 / sigma**2}
+
+    def dl1_dp1(self, y: np.ndarray, theta: np.ndarray, param: int = 0) -> np.ndarray:
+        mu, sigma = self.theta_to_params(theta)
+        if param == 0:
+            # (y-mu)/((sigma^2)*(mu^3))
+            return (y - mu) / (sigma**2 * mu**3)
+        if param == 1:
+            # (-1/sigma) +((y-mu)^2)/(y*(sigma^3)*(mu^2)),
+            return (-1 / sigma) + ((y - mu) ** 2) / (sigma**3 * mu**2 * y)
+        raise ValueError("param must be 0 (mu) or 1 (sigma)")
+
+    def dl2_dp2(self, y: np.ndarray, theta: np.ndarray, param: int = 0) -> np.ndarray:
+        mu, sigma = self.theta_to_params(theta)
+        if param == 0:
+            # -1/((mu^3)*(sigma^2)),
+            return -1 / (mu**3 * sigma**2)
+        if param == 1:
+            # -2/(sigma^2),
+            return -2 / (sigma**2)
+        raise ValueError("param must be 0 (mu) or 1 (sigma)")
+
+    def dl2_dpp(
+        self, y: np.ndarray, theta: np.ndarray, params: tuple[int, int] = (0, 1)
+    ) -> np.ndarray:
+        if params[0] == params[1]:
+            raise ValueError("Cross derivatives must use different parameters.")
+        return np.zeros_like(y)
+
+    def initial_values(self, y: np.ndarray) -> np.ndarray:
+        mu_init = np.mean(y)
+        sigma_init = np.std(y) / np.sqrt(np.mean(y))
+        initial_params = [mu_init, sigma_init]
+        return np.tile(initial_params, (y.shape[0], 1))

--- a/src/ondil/distributions/inversegaussian.py
+++ b/src/ondil/distributions/inversegaussian.py
@@ -62,7 +62,7 @@ class DistributionInverseGaussian(ScipyMixin, Distribution):
 
     def theta_to_scipy_params(self, theta: np.ndarray) -> dict:
         mu, sigma = self.theta_to_params(theta)
-        return {"mu": mu * sigma**2, "loc": 0, "scale": 1 / sigma**2}
+        return {"mu": mu * sigma**2, "loc": np.zeros_like(mu), "scale": 1 / sigma**2}
 
     def dl1_dp1(self, y: np.ndarray, theta: np.ndarray, param: int = 0) -> np.ndarray:
         mu, sigma = self.theta_to_params(theta)

--- a/tests/distributions/inversegaussian/test_coefs.py
+++ b/tests/distributions/inversegaussian/test_coefs.py
@@ -1,0 +1,53 @@
+import numpy as np
+import rpy2.robjects as robjects
+
+from ondil import DistributionInverseGaussian, OnlineGamlss
+
+file = "tests/data/mtcars.csv"
+mtcars = np.genfromtxt(file, delimiter=",", skip_header=1)[:, 1:]
+
+y = mtcars[:, 0]
+X = mtcars[:, 1:]
+
+
+def test_inversegaussian_distribution():
+    dist = DistributionInverseGaussian()
+
+    code = f"""
+    library("gamlss")
+    data(mtcars)
+
+    model = gamlss(
+        mpg ~ cyl + hp,
+        sigma.formula = ~cyl + hp,
+        family=gamlss.dist::{dist.corresponding_gamlss}(),
+        data=as.data.frame(mtcars)
+    )
+
+    list(
+        "mu" = coef(model, "mu"),
+        "sigma" = coef(model, "sigma")
+    )
+    """
+
+    R_list = robjects.r(code)
+    coef_R_mu = np.array(R_list.rx2("mu"))
+    coef_R_sg = np.array(R_list.rx2("sigma"))
+
+    estimator = OnlineGamlss(
+        distribution=dist,
+        equation={0: np.array([0, 2]), 1: np.array([0, 2])},
+        method="ols",
+        scale_inputs=False,
+        fit_intercept=True,
+        rss_tol_inner=10,
+    )
+
+    estimator.fit(X=X, y=y)
+
+    assert np.allclose(
+        estimator.beta[0], coef_R_mu, atol=0.01
+    ), "Location coefficients don't match"
+    assert np.allclose(
+        estimator.beta[1], coef_R_sg, atol=0.01
+    ), "Scale coefficients don't match"

--- a/tests/distributions/inversegaussian/test_derivatives.py
+++ b/tests/distributions/inversegaussian/test_derivatives.py
@@ -1,0 +1,56 @@
+import numpy as np
+import rpy2.robjects as robjects
+
+from ondil import DistributionInverseGaussian
+
+
+def test_inversegaussian_derivatives():
+    code = """
+    library(gamlss.dist)
+    set.seed(1)
+    y <- rep(1.5, 3)
+    mu <- rexp(3, rate = 1) + 0.1
+    sigma <- rexp(3, rate = 1) + 0.1
+    dist <- gamlss.dist::IG()
+    list(
+      "y" = y,
+      "mu" = mu,
+      "sigma" = sigma,
+      "dldm" = dist$dldm(y, mu, sigma),
+      "d2ldm2" = dist$d2ldm2(mu, sigma),
+      "dldd" = dist$dldd(y, mu, sigma),
+      "d2ldd2" = dist$d2ldd2(sigma),
+      "d2ldmdd" = dist$d2ldmdd(y)
+    )
+    """
+
+    R_list = robjects.r(code)
+
+    y = np.array(R_list.rx2("y"))
+    mu = np.array(R_list.rx2("mu"))
+    sigma = np.array(R_list.rx2("sigma"))
+    theta = np.array([mu, sigma])
+
+    dist = DistributionInverseGaussian()
+
+    dl1_dp1_0 = dist.dl1_dp1(y, theta=theta.T, param=0)
+    dl2_dp2_0 = dist.dl2_dp2(y, theta=theta.T, param=0)
+    dl1_dp1_1 = dist.dl1_dp1(y, theta=theta.T, param=1)
+    dl2_dp2_1 = dist.dl2_dp2(y, theta=theta.T, param=1)
+    dl2_dpp_01 = dist.dl2_dpp(y, theta=theta.T, params=(0, 1))
+
+    assert np.allclose(
+        dl1_dp1_0, R_list.rx2("dldm")
+    ), "First derivative wrt mu doesn't match"
+    assert np.allclose(
+        dl2_dp2_0, R_list.rx2("d2ldm2")
+    ), "Second derivative wrt mu doesn't match"
+    assert np.allclose(
+        dl1_dp1_1, R_list.rx2("dldd")
+    ), "First derivative wrt sigma doesn't match"
+    assert np.allclose(
+        dl2_dp2_1, R_list.rx2("d2ldd2")
+    ), "Second derivative wrt sigma doesn't match"
+    assert np.allclose(
+        dl2_dpp_01, R_list.rx2("d2ldmdd")
+    ), "Cross derivative doesn't match"

--- a/tests/distributions/inversegaussian/test_dist.py
+++ b/tests/distributions/inversegaussian/test_dist.py
@@ -1,0 +1,49 @@
+import numpy as np
+import rpy2.robjects as robjects
+
+from ondil import DistributionInverseGaussian
+
+
+def test_inversegaussian_distribution():
+    dist = DistributionInverseGaussian()
+
+    code = f"""
+    library(gamlss.dist)
+    set.seed(1)
+    y <- rIG(3, mu = 2, sigma = 1)  # generate y values > 0
+    mu <- rexp(3, rate = 1) + 0.1   # ensure mu > 0
+    sigma <- rexp(3, rate = 1) + 0.1  # ensure sigma > 0
+
+    list(
+      "y" = y,
+      "mu" = mu,
+      "sigma" = sigma,
+      "cdf" = pIG(y, mu = mu, sigma = sigma),
+      "pdf" = dIG(y, mu = mu, sigma = sigma),
+      "ppf" = qIG(p = pIG(y, mu = mu, sigma = sigma), mu = mu, sigma = sigma)
+    )
+    """
+
+    R_list = robjects.r(code)
+
+    y = np.array(R_list.rx2("y"))
+    theta = np.array(
+        [
+            R_list.rx2("mu"),
+            R_list.rx2("sigma"),
+        ]
+    )
+
+    cdf = dist.cdf(y, theta=theta.T)
+    pdf = dist.pdf(y, theta=theta.T)
+    ppf = dist.ppf(cdf, theta=theta.T)
+
+    assert np.allclose(
+        cdf, R_list.rx2("cdf")
+    ), "Probabilities don't match, inspect the cdf function"
+    assert np.allclose(
+        pdf, R_list.rx2("pdf")
+    ), "Densities don't match, inspect the pdf function"
+    assert np.allclose(
+        ppf, R_list.rx2("ppf"), atol=1e-3, rtol=1e-3
+    ), "Quantiles don't match, inspect the ppf function"

--- a/tests/distributions/inversegaussian/test_dist.py
+++ b/tests/distributions/inversegaussian/test_dist.py
@@ -7,7 +7,7 @@ from ondil import DistributionInverseGaussian
 def test_inversegaussian_distribution():
     dist = DistributionInverseGaussian()
 
-    code = f"""
+    code = """
     library(gamlss.dist)
     set.seed(1)
     y <- rIG(3, mu = 2, sigma = 1)  # generate y values > 0
@@ -38,12 +38,12 @@ def test_inversegaussian_distribution():
     pdf = dist.pdf(y, theta=theta.T)
     ppf = dist.ppf(cdf, theta=theta.T)
 
-    assert np.allclose(
-        cdf, R_list.rx2("cdf")
-    ), "Probabilities don't match, inspect the cdf function"
-    assert np.allclose(
-        pdf, R_list.rx2("pdf")
-    ), "Densities don't match, inspect the pdf function"
-    assert np.allclose(
-        ppf, R_list.rx2("ppf"), atol=1e-3, rtol=1e-3
-    ), "Quantiles don't match, inspect the ppf function"
+    assert np.allclose(cdf, R_list.rx2("cdf")), (
+        "Probabilities don't match, inspect the cdf function"
+    )
+    assert np.allclose(pdf, R_list.rx2("pdf")), (
+        "Densities don't match, inspect the pdf function"
+    )
+    assert np.allclose(ppf, R_list.rx2("ppf"), atol=1e-3, rtol=1e-3), (
+        "Quantiles don't match, inspect the ppf function"
+    )


### PR DESCRIPTION
This PR introduces the Inverse Gaussian

Needs a somewhat tricky reparameterization which is described in the docs.

I'm not super happy with the reduced tolerance in the quantile function test.


## Checklist

- [x] Implement distribution in `src/ondil/distributions/new_dist.py`
- [x] Add the distribution to the documentation under `docs/distributions.md`
- [x] Add a proper docstring describing the definition of the distribution and possible parameterizations
- [x] Implement tests for the derivatives using `rpy2` - see `tests/distributions`
- [x] Implement a small test for the coefficients on the MTCARS test data set - see `tests/distributions`
- [x] All tests are passing

This relates to #104 