### PR TITLE
Add parameterized test for derivatives of distribution functions

### DIFF
--- a/tests/distributions/test_derivatives.py
+++ b/tests/distributions/test_derivatives.py
@@ -1,0 +1,78 @@
+# %%
+import numpy as np
+import pytest
+import rpy2.robjects as robjects
+import ondil.distributions
+
+N = 100
+CLIP_BOUNDS = (-1e5, 1e5)
+
+
+@pytest.mark.parametrize(
+    "distribution",
+    [
+        ondil.distributions.DistributionLogistic(),
+        ondil.distributions.DistributionNormal(),
+        ondil.distributions.DistributionLogNormalMedian(),
+        # ondil.distributions.DistributionExponential(),
+        ondil.distributions.DistributionGamma(),
+        ondil.distributions.DistributionInverseGaussian(),
+        ondil.distributions.DistributionBeta(),
+        ondil.distributions.DistributionJSU(),
+        ondil.distributions.DistributionT(),
+        # ondil.distributions.DistributionNormalMeanVariance(),
+    ],
+    ids=lambda dist: dist.__class__.__name__,
+)
+def test_distribution_derivatives(distribution):
+    """Test that Python derivatives match R GAMLSS derivatives for different distributions."""
+
+    # Generate random data within distribution support
+    y = np.random.uniform(
+        np.clip(distribution.distribution_support[0], *CLIP_BOUNDS),
+        np.clip(distribution.distribution_support[1], *CLIP_BOUNDS),
+        N,
+    )
+    robjects.globalenv["y"] = robjects.FloatVector(y)
+
+    # Generate random parameters within support bounds
+    theta = np.array(
+        [
+            np.random.uniform(
+                np.clip(distribution.parameter_support[i][0], *CLIP_BOUNDS),
+                np.clip(distribution.parameter_support[i][1], *CLIP_BOUNDS),
+                N,
+            )
+            for i in range(distribution.n_params)
+        ]
+    ).T
+
+    # Assign R variables programmatically
+    for i, param_name in distribution.parameter_names.items():
+        robjects.globalenv[param_name] = robjects.FloatVector(theta[:, i])
+
+    # Obtain derivatives from R
+    code = f"""
+        dist <- gamlss.dist::{distribution.corresponding_gamlss}()
+        derivative_funcs <- c('dldm', 'dldd', 'd2ldm2', 'd2ldd2', 'd2ldmdd')
+        setNames(lapply(derivative_funcs, function(f) {{
+          do.call(dist[[f]], mget(names(formals(dist[[f]])), envir = .GlobalEnv))
+        }}), derivative_funcs)
+        """
+
+    R_list = robjects.r(code)
+
+    # Map R derivative names to Python method calls
+    derivative_mapping = {
+        "dldm": lambda: distribution.dl1_dp1(y, theta=theta, param=0),
+        "dldd": lambda: distribution.dl1_dp1(y, theta=theta, param=1),
+        "d2ldm2": lambda: distribution.dl2_dp2(y, theta=theta, param=0),
+        "d2ldd2": lambda: distribution.dl2_dp2(y, theta=theta, param=1),
+        "d2ldmdd": lambda: distribution.dl2_dpp(y, theta=theta, params=(0, 1)),
+    }
+
+    # Compare R and Python derivatives
+    for key, python_func in derivative_mapping.items():
+        assert np.allclose(python_func(), R_list.rx2(key)), (
+            f"Derivative {key} doesn't match for {distribution.__class__.__name__}"
+        )


### PR DESCRIPTION
This closes #96 

This PR adds parameterized tests for distributions. That is, we do not need to write tests for new distributions from scratch. We can just add the new distributions to the existing parameterized test files. The current implementation works for most of the distributions. However, 2 are failing:

![image](https://github.com/user-attachments/assets/db39f22e-7db0-48b2-8370-0a5b00ebeb82)

I'll investigate why.

Testing the CDF, PDF, etc. should be possible in a similar way. Testing the coeffs needs some additional brainpower as we need to transform the input data for some distributions.