### PR TITLE
sklearn compliance for OnlineLasso

### DIFF
--- a/src/ondil/estimators/online_lasso.py
+++ b/src/ondil/estimators/online_lasso.py
@@ -46,6 +46,16 @@ class OnlineLasso(OnlineLinearModel):
             selection (Literal["cyclic", "random"], optional): Whether to cycle through all coordinates in order or random. For large problems, random might increase convergence. Defaults to 100.
         """
 
+        self.lambda_n = lambda_n
+        self.lambda_eps = lambda_eps
+        self.start_value = start_value
+        self.tolerance = tolerance
+        self.max_iterations = max_iterations
+        self.selection = selection
+        self.beta_lower_bound = beta_lower_bound
+        self.beta_upper_bound = beta_upper_bound
+        self.early_stop = early_stop
+
         concrete_method = LassoPath(
             lambda_eps=lambda_eps,
             lambda_n=lambda_n,

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1,8 +1,8 @@
-import ondil.estimators
 import pytest
 from sklearn.utils.estimator_checks import check_estimator
 
 import ondil
+import ondil.estimators
 
 EXPECTED_FAILED_CHECKS = {
     "check_sample_weight_equivalence_on_dense_data": "To few data points to test this check in the original sklaern implementation.",
@@ -21,6 +21,30 @@ def test_sklearn_compliance_linear_model(scale_inputs, fit_intercept, method, ic
         scale_inputs=scale_inputs,
         method=method,
         ic=ic,
+    )
+    check_estimator(
+        estimator, on_fail="raise", expected_failed_checks=EXPECTED_FAILED_CHECKS
+    )
+
+
+@pytest.mark.parametrize("scale_inputs", [False, True])
+@pytest.mark.parametrize("fit_intercept", [False, True])
+@pytest.mark.parametrize("ic", ["aic", "bic", "hqc", "max"])
+@pytest.mark.parametrize("lambda_n", [50, 100])
+@pytest.mark.parametrize("lambda_eps", [1e-4, 1e-2])
+def test_sklearn_compliance_lasso_model(
+    scale_inputs: bool,
+    fit_intercept: bool,
+    ic: str,
+    lambda_n: int,
+    lambda_eps: float,
+):
+    estimator = ondil.estimators.OnlineLasso(
+        fit_intercept=fit_intercept,
+        scale_inputs=scale_inputs,
+        ic=ic,
+        lambda_n=lambda_n,
+        lambda_eps=lambda_eps,
     )
     check_estimator(
         estimator, on_fail="raise", expected_failed_checks=EXPECTED_FAILED_CHECKS


### PR DESCRIPTION
## Fix: sklearn compliance for OnlineLasso

### Description

This PR fixes the following issue: 

The OnlineLasso was not compatible with sklearn since we did not save all attributes passed in the init to the estimator. Therefore the estimator could not be cloned

This fix addresses the problem by 

- Saving all attributes
- Adding a test to avoid regression.

### Checklist

- [x] Identify the root cause of the issue
- [x] Implement the fix in the appropriate module
- [x] Add tests to ensure the issue is resolved